### PR TITLE
change return in gradient kernel

### DIFF
--- a/flowpm/kernels.py
+++ b/flowpm/kernels.py
@@ -63,12 +63,11 @@ def gradient_kernel(kvec, direction, order=0):
     Complex kernel
   """
   if order == 0:
-    mask = np.ones_like(kvec[direction])
-    mask = mask.squeeze()
-    mask[len(mask) // 2] = 0 # Set nyquist to 0 to ensure real field
-    mask = mask.reshape(kvec[direction].shape)
-    wts = 1j * kvec[direction] * mask
-    return wts[:]
+    wts = 1j * kvec[direction] 
+    wts = np.squeeze(wts)
+    wts[len(wts) //2] = 0
+    wts = wts.reshape(kvec[direction].shape)
+    return wts
   else:
     nc = len(kvec[0])
     w = kvec[direction]

--- a/flowpm/kernels.py
+++ b/flowpm/kernels.py
@@ -67,7 +67,8 @@ def gradient_kernel(kvec, direction, order=0):
     mask = mask.squeeze()
     mask[len(mask) // 2] = 0 # Set nyquist to 0 to ensure real field
     mask = mask.reshape(kvec[direction].shape)
-    return 1j * kvec[direction] * mask
+    wts = 1j * kvec[direction] * mask
+    return wts[:]
   else:
     nc = len(kvec[0])
     w = kvec[direction]

--- a/flowpm/tfpm.py
+++ b/flowpm/tfpm.py
@@ -79,8 +79,9 @@ def lpt1(dlin_k, pos, kvec=None, name=None):
       dispc = tf.multiply(dlin_k, kweight)
       disp = c2r3d(dispc, norm=nc**3)
       displacement.append(cic_readout(disp, pos))
-    return tf.stack(displacement, axis=2)
-
+    displacement = tf.stack(displacement, axis=2)
+    return displacement
+#    
 def lpt2_source(dlin_k, kvec=None, name=None):
   """ Generate the second order LPT source term.
 


### PR DESCRIPTION
Issue: for N>63, the output of nbody was equal = 1 over whole mesh.
Cause: gradient kernel returned 0s for order=1, hence the initial displacements in 'lpt1=0'
Fix: "return wts[:]" instead of "return wts"
(underlying cause is not completely understood yet)