### PR TITLE
Restricts tensorflow version to pre-v2 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='flowpm',
       author_email='modichirag@berkeley.edu',
       license='MIT',
       packages=['flowpm'],
-      install_requires=['astropy', 'scipy', 'tensorflow==1.14'],
+      install_requires=['astropy', 'scipy', 'tensorflow<2.0.0'],
       tests_require=['fastpm'],
       extras_require={
         'testing':  ["fastpm"],

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='flowpm',
       author_email='modichirag@berkeley.edu',
       license='MIT',
       packages=['flowpm'],
-      install_requires=['astropy', 'scipy', 'tensorflow'],
+      install_requires=['astropy', 'scipy', 'tensorflow==1.14'],
       tests_require=['fastpm'],
       extras_require={
         'testing':  ["fastpm"],


### PR DESCRIPTION
This small PR makes sure flowpm is built against tensorflow v1, until we make it compatible with v2.