### PR TITLE
Adds modification to cache growth ODE

### DIFF
--- a/flowpm/tfbackground.py
+++ b/flowpm/tfbackground.py
@@ -288,10 +288,8 @@ def growth_ode(a, y, **cosmo):
     \right) a \frac{dD_1}{da}=\frac{3}{2}  \Omega_{m}(a)D_1
      (see :cite:`Florent Leclercq thesis` Eq. (1.96))
     """
-    #y=tf.convert_to_tensor(y,dtype=tf.float32)
     a=tf.convert_to_tensor(a,dtype=tf.float32)
     # Extracting entries
-    print(y)
     (d1, d2), (d1_f, d2_f) = y
     # ODE for d1
     dy1dt= d1_f,1.5*Omega_m_a(cosmo,a)*d1/tf.pow(a,2)-(d1_f/a)*(Omega_de_a(cosmo,a)-0.5*Omega_m_a(cosmo,a)+2)
@@ -620,7 +618,7 @@ def gf2(cosmo, a):
                       tf.math.log(cache['a'][0]), tf.math.log(cache['a'][-1]), cache['F2p'])
     return  (f2p * a ** 3 *E(cosmo,a) +  d2f*a ** 3 * dEa(cosmo,a) + 3 * a ** 2 * E(cosmo,a)*d2f)
 
-# 
+#
 # if __name__ == "__main__":
 #   """ Tests implementation and draws first and second order growth.
 #   """

--- a/tests/tf_background_test.py
+++ b/tests/tf_background_test.py
@@ -1,8 +1,8 @@
 import tensorflow as tf
 import numpy as np
-from flowpm.tfbackground import dEa,Omega_m_a, F1, E, F2, Gf,Gf2, gf,gf2,D1_norm,D2_norm,D1f_norm,D2f_norm
+from flowpm.tfbackground import dEa,Omega_m_a, E, Gf,Gf2, gf,gf2,D1,D2,D1f,D2f, f1,f2
 from numpy.testing import assert_allclose
-from flowpm.background import MatterDominated 
+from flowpm.background import MatterDominated
 
 
 
@@ -41,7 +41,7 @@ def test_Eprime():
   E_prim_back=M_d.efunc_prime(a)
   # Computing new E' function with tensorflow
   E_n = dEa(cosmo, a)
-  
+
   assert_allclose(E_prim_back, E_n, rtol=1e-4)
 
 
@@ -58,39 +58,37 @@ def test_Omega_m():
   assert_allclose(Omega_back, Omega_m_n, rtol=1e-4)
 
 
-
-
 def test_growth_1order():
-    """ Testing linear growth factor D_1(a) 
+    """ Testing linear growth factor D_1(a)
     """
-    
+
     M_d=MatterDominated(Omega0_m=0.3075)
     a =np.logspace(-2, 0.0, 128)
     gback = M_d.D1(a)
-    gtfback =D1_norm(a)
+    gtfback =D1(cosmo, a)
 
     assert_allclose(gback, gtfback, rtol=1e-2)
 
 
 def test_growth_2order():
-    """ Testing linear growth factor D_2(a) 
+    """ Testing linear growth factor D_2(a)
     """
-    
+
     M_d=MatterDominated(Omega0_m=0.3075)
     a = np.logspace(-2, 0.0,128)
     g2back = M_d.D2(a)
-    g2tfback =D2_norm(a)
+    g2tfback =D2(cosmo, a)
 
     assert_allclose(g2back, g2tfback, rtol=1e-2)
-    
+
 def test_D1_fnorm():
-    """ Testing  D'_1(a) 
+    """ Testing  D'_1(a)
     """
-    
+
     M_d=MatterDominated(Omega0_m=0.3075)
     a =np.logspace(-2, 0.0, 128)
     gback = M_d.gp(a)
-    gtfback =D1f_norm(a)
+    gtfback =D1f(cosmo,a)
 
     assert_allclose(gback, gtfback, rtol=1e-2)
 
@@ -98,65 +96,64 @@ def test_D1_fnorm():
 def test_D2_fnorm():
     """ Testing  D'_2(a)
     """
-    
+
     M_d=MatterDominated(Omega0_m=0.3075)
     a = np.logspace(-2, 0.0,128)
     g2back = M_d.gp2(a)
-    g2tfback =D2f_norm(a)
+    g2tfback =D2f(cosmo,a)
 
-    assert_allclose(g2back, g2tfback, rtol=1e-2)    
-    
-    
+    assert_allclose(g2back, g2tfback, rtol=1e-2)
+
+
 # =============================================================================
 def testf1():
     M_d=MatterDominated(Omega0_m=0.3075)
     a = np.logspace(-2, 0,128)
     f1_back=M_d.f1(a)
-    f1_tf=F1(a)
-    
+    f1_tf=f1(cosmo, a)
+
     assert_allclose(f1_back, f1_tf, rtol=1e-2)
-    
-    
-    
+
+
+
 def testf2():
     M_d=MatterDominated(Omega0_m=0.3075)
     a = np.logspace(-2, 0,128)
     f2_back=M_d.f2(a)
-    f2_tf=F2(a)
-    
+    f2_tf=f2(cosmo, a)
+
     assert_allclose(f2_back, f2_tf, rtol=1e-2)
-    
-    
+
+
 def testGf():
     M_d=MatterDominated(Omega0_m=0.3075)
     a = np.logspace(-2, 0,128)
     Gf_back=M_d.Gf(a)
-    Gf_tf=Gf(a)
-    
+    Gf_tf=Gf(cosmo, a)
+
     assert_allclose(Gf_back, Gf_tf, rtol=1e-2)
-    
+
 def testGf2():
     M_d=MatterDominated(Omega0_m=0.3075)
     a = np.logspace(-2, 0,128)
     Gf2_back=M_d.Gf2(a)
-    Gf2_tf=Gf2(a)
-    
+    Gf2_tf=Gf2(cosmo, a)
+
     assert_allclose(Gf2_back, Gf2_tf, rtol=1e-2)
-    
-    
+
+
 def testgf():
     M_d=MatterDominated(Omega0_m=0.3075)
     a = np.logspace(-2, 0,128)
     gf_back=M_d.gf(a)
-    gf_tf=gf(a)
-    
+    gf_tf=gf(cosmo, a)
+
     assert_allclose(gf_back, gf_tf, rtol=1e-2)
-    
+
 def testgf2():
     M_d=MatterDominated(Omega0_m=0.3075)
     a = np.logspace(-2, 0,128)
     gf2_back=M_d.gf2(a)
-    gf2_tf=gf2(a)
-    
+    gf2_tf=gf2(cosmo, a)
+
     assert_allclose(gf2_back, gf2_tf, rtol=1e-2)
-    


### PR DESCRIPTION
This PR adds a caching mechanism that ensures that the ODE is called only once, and then subsequent calls are interpolated from  an interpolation table.

@dlanzieri please review this PR and let me know what you think :-)

A few observations on the modifications I've made:
- There is now only one place where the ODE function is called. In general, duplicating identical code is a big no-no, because if you change the ODE in one function, you may forget to update the other functions.

- I use the ODE function itself to compute second order growth instead of replicating the code for the ODE in functions `gf` and `gf2`. It's the same approach that was taken in the original code here: 
https://github.com/modichirag/flowpm/blob/d4b4872c824c482f8315737c50181b4630453da1/flowpm/background.py#L196

- a few functions didn't have a `cosmo` parameter ^^' so I added it, but the documentations are missing this argument

I hope now everything should work fine