### PR TITLE
Adds support for non cubic simulations

### DIFF
--- a/flowpm/tfpm.py
+++ b/flowpm/tfpm.py
@@ -24,11 +24,12 @@ def linear_field(nc, boxsize, pk, kvec=None, batch_size=1,
 
   Parameters:
   -----------
-  nc: int
-    Number of cells in the field
+  nc: int, or list of ints
+    Number of cells in the field. If a list is provided, number of cells per
+    dimension.
 
-  boxsize: float
-    Physical size of the cube, in Mpc/h TODO: confirm units
+  boxsize: float, or list of floats
+    Physical size of the cube, in Mpc/h.
 
   pk: interpolator
     Power spectrum to use for the field
@@ -51,14 +52,20 @@ def linear_field(nc, boxsize, pk, kvec=None, batch_size=1,
     Realization of the linear field with requested power spectrum
   """
   with tf.name_scope(name):
+    # Transform nc to a list of necessary
+    if isinstance(nc, int):
+      nc = [nc,nc,nc]
+    if isinstance(boxsize, int) or isinstance(boxsize, float):
+       boxsize = [boxsize, boxsize, boxsize]
+
     if kvec is None:
-      kvec = fftk((nc, nc, nc), symmetric=False)
-    kmesh = sum((kk / boxsize * nc)**2 for kk in kvec)**0.5
+      kvec = fftk(nc, symmetric=False)
+    kmesh = sum((kk / boxsize[i] * nc[i])**2 for i,kk in enumerate(kvec))**0.5
     pkmesh = pk(kmesh)
 
     whitec = white_noise(nc, batch_size=batch_size, seed=seed, type='complex')
-    lineark = tf.multiply(whitec, (pkmesh/boxsize**3)**0.5)
-    linear = c2r3d(lineark, norm=nc**3, name=name, dtype=dtype)
+    lineark = tf.multiply(whitec, (pkmesh/(boxsize[0]*boxsize[1]*boxsize[2]))**0.5)
+    linear = c2r3d(lineark, norm=nc[0]*nc[1]*nc[2], name=name, dtype=dtype)
     return linear
 
 def lpt1(dlin_k, pos, kvec=None, name="LTP1"):
@@ -79,9 +86,9 @@ def lpt1(dlin_k, pos, kvec=None, name="LTP1"):
     pos = tf.convert_to_tensor(pos, name="pos")
 
     shape = dlin_k.get_shape()
-    batch_size, nc = shape[0], shape[1]
+    batch_size, nc = shape[0], shape[1:]
     if kvec is None:
-      kvec = fftk((nc, nc, nc), symmetric=False)
+      kvec = fftk(nc, symmetric=False)
 
     lap = tf.cast(laplace_kernel(kvec), tf.complex64)
 
@@ -89,7 +96,7 @@ def lpt1(dlin_k, pos, kvec=None, name="LTP1"):
     for d in range(3):
       kweight = gradient_kernel(kvec, d) * lap
       dispc = tf.multiply(dlin_k, kweight)
-      disp = c2r3d(dispc, norm=nc**3)
+      disp = c2r3d(dispc, norm=nc[0]*nc[1]*nc[2])
       displacement.append(cic_readout(disp, pos))
     displacement = tf.stack(displacement, axis=2)
     return displacement
@@ -110,9 +117,9 @@ def lpt2_source(dlin_k, kvec=None, name="LPT2Source"):
     dlin_k = tf.convert_to_tensor(dlin_k, name="lineark")
 
     shape = dlin_k.get_shape()
-    batch_size, nc = shape[0], shape[1]
+    batch_size, nc = shape[0], shape[1:]
     if kvec is None:
-      kvec = fftk((nc, nc, nc), symmetric=False)
+      kvec = fftk(nc, symmetric=False)
     source = tf.zeros(tf.shape(dlin_k))
     D1 = [1, 2, 0]
     D2 = [2, 0, 1]
@@ -125,7 +132,7 @@ def lpt2_source(dlin_k, kvec=None, name="LPT2Source"):
         grad = gradient_kernel(kvec, d)
         kweight = lap * grad * grad
         phic = tf.multiply(dlin_k, kweight)
-        phi_ii.append(c2r3d(phic, norm=nc**3))
+        phi_ii.append(c2r3d(phic, norm=nc[0]*nc[1]*nc[2]))
 
     for d in range(3):
         source = tf.add(source, tf.multiply(phi_ii[D1[d]], phi_ii[D2[d]]))
@@ -139,11 +146,11 @@ def lpt2_source(dlin_k, kvec=None, name="LPT2Source"):
         gradj = gradient_kernel(kvec, D2[d])
         kweight = lap * gradi * gradj
         phic = tf.multiply(dlin_k, kweight)
-        phi = c2r3d(phic, norm=nc**3)
+        phi = c2r3d(phic, norm=nc[0]*nc[1]*nc[2])
         source = tf.subtract(source, tf.multiply(phi, phi))
 
     source = tf.multiply(source, 3.0/7.)
-    return r2c3d(source, norm=nc**3)
+    return r2c3d(source, norm=nc[0]*nc[1]*nc[2])
 
 def lpt_init(linear, a0, order=2, cosmology=Planck15, kvec=None, name="LPTInit"):
   """ Estimate the initial LPT displacement given an input linear (real) field
@@ -157,16 +164,16 @@ def lpt_init(linear, a0, order=2, cosmology=Planck15, kvec=None, name="LPTInit")
 
     assert order in (1, 2)
     shape = linear.get_shape()
-    batch_size, nc = shape[0], shape[1]
+    batch_size, nc = shape[0], shape[1:]
 
     dtype = np.float32
-    Q = np.indices((nc, nc, nc)).reshape(3, -1).T.astype(dtype)
+    Q = np.indices(nc).reshape(3, -1).T.astype(dtype)
     Q = np.repeat(Q.reshape((1, -1, 3)), batch_size, axis=0)
     pos = Q
 
     a = a0
 
-    lineark = r2c3d(linear, norm=nc**3)
+    lineark = r2c3d(linear, norm=nc[0]*nc[1]*nc[2])
 
     pt = PerturbationGrowth(cosmology, a=[a], a_normalize=1.0)
     DX = tf.multiply(dtype(pt.D1(a)) , lpt1(lineark, pos))
@@ -193,13 +200,13 @@ def apply_longrange(x, delta_k, split=0, factor=1, kvec=None, name="ApplyLongran
     delta_k = tf.convert_to_tensor(delta_k, name="delta_k")
 
     shape = delta_k.get_shape()
-    batch_size, nc = shape[1], shape[2]
+    nc = shape[1:]
 
     if kvec is None:
-      kvec = fftk((nc, nc, nc), symmetric=False)
+      kvec = fftk(nc, symmetric=False)
 
     ndim = 3
-    norm = nc**3
+    norm = nc[0]*nc[1]*nc[2]
     lap = tf.cast(laplace_kernel(kvec), tf.complex64)
     fknlrange = longrange_kernel(kvec, split)
     kweight = lap * fknlrange
@@ -286,15 +293,15 @@ def force(state, nc, cosmology=Planck15, pm_nc_factor=1, kvec=None,
 
     shape = state.get_shape()
     batch_size = shape[1]
-    ncf = nc * pm_nc_factor
+    ncf = [n * pm_nc_factor for n in nc]
 
-    rho = tf.zeros((batch_size, ncf, ncf, ncf))
-    wts = tf.ones((batch_size, nc**3))
-    nbar = nc**3/ncf**3
+    rho = tf.zeros([batch_size] + ncf)
+    wts = tf.ones((batch_size, nc[0]*nc[1]*nc[2]))
+    nbar = nc[0]*nc[1]*nc[2]/(ncf[0]*ncf[1]*ncf[2])
 
     rho = cic_paint(rho, tf.multiply(state[0], pm_nc_factor), wts)
     rho = tf.multiply(rho, 1./nbar)  ###I am not sure why this is not needed here
-    delta_k = r2c3d(rho, norm=ncf**3)
+    delta_k = r2c3d(rho, norm=ncf[0]*ncf[1]*ncf[2])
     fac = dtype(1.5 * cosmology.Om0)
     update = apply_longrange(tf.multiply(state[0], pm_nc_factor), delta_k, split=0, factor=fac)
 
@@ -320,7 +327,7 @@ def nbody(state, stages, nc, cosmology=Planck15, pm_nc_factor=1, name="NBody"):
   stages: array
     Array of scale factors
 
-  nc: int
+  nc: int, or list of ints
     Number of cells
 
   pm_nc_factor: int
@@ -335,6 +342,8 @@ def nbody(state, stages, nc, cosmology=Planck15, pm_nc_factor=1, name="NBody"):
     state = tf.convert_to_tensor(state, name="state")
 
     shape = state.get_shape()
+    if isinstance(nc, int):
+      nc = [nc,nc,nc]
 
     # Unrolling leapfrog integration to make tf Autograph happy
     if len(stages) == 0:

--- a/flowpm/utils.py
+++ b/flowpm/utils.py
@@ -30,7 +30,7 @@ def cic_paint(mesh, part, weight=None, name="CiCPaint"):
 
     shape = tf.shape(mesh)
     batch_size, nx, ny, nz = shape[0], shape[1], shape[2], shape[3]
-    nc = nz
+    nc = [nx,ny,nz]
 
     # Flatten part if it's not already done
     if len(part.shape) > 3:
@@ -90,7 +90,7 @@ def cic_readout(mesh, part, name="CiCReadout"):
 
     shape = tf.shape(mesh)
     batch_size, nx, ny, nz = shape[0], shape[1], shape[2], shape[3]
-    nc = nz
+    nc = [nx,ny,nz]
 
     # Flatten part if it's not already done
     if len(part.shape) > 3:
@@ -174,10 +174,13 @@ def white_noise(nc, batch_size=1, seed=None, type='complex', name="WhiteNoise"):
   Samples a 3D cube of white noise of desired size
   """
   with tf.name_scope(name):
-    assert batch_size >= 1
-    white = tf.random.normal(shape=(batch_size, nc, nc, nc),
-                             mean=0, stddev=nc**1.5, seed=seed)
+    # Transform nc to a list of necessary
+    if isinstance(nc, int):
+      nc = [nc,nc,nc]
+
+    white = tf.random.normal(shape=[batch_size]+nc,
+                             mean=0., stddev=(nc[0]*nc[1]*nc[2])**0.5, seed=seed)
     if type == 'real': return white
     elif type == 'complex':
-        whitec = r2c3d(white, norm=nc**3)
+        whitec = r2c3d(white, norm=nc[0]*nc[1]*nc[2])
         return whitec


### PR DESCRIPTION
This small PR generalizes the single GPU TensorFlow FlowPM to support non cubic volumes, for instance with one dimension far more extended than the other, for reasons ;-) 

The changes are minimal, to create a rectangular simulation simply do the following:
```python
initial_conditions = flowpm.linear_field([32,32,320],     # size of the cube
                                         [100,100,1000],  # Physical size of the cube
                                         ipklin,          # Initial powerspectrum
                                         batch_size=1)
state = flowpm.lpt_init(initial_conditions, a0=0.1)   
final_state = flowpm.nbody(state, stages, [32,32,320])    
```
and you get this pretty picture:
![image](https://user-images.githubusercontent.com/861591/100524950-efb28980-31bc-11eb-8207-a076615d3839.png)

It's tested against python_fastpm so should be good to go