### PR TITLE
Changes the API for cosmological parameters

### DIFF
--- a/flowpm/__init__.py
+++ b/flowpm/__init__.py
@@ -1,2 +1,3 @@
 from .utils import cic_paint, cic_readout
 from .tfpm import nbody, linear_field, lpt_init
+import cosmology

--- a/flowpm/__init__.py
+++ b/flowpm/__init__.py
@@ -1,3 +1,3 @@
 from .utils import cic_paint, cic_readout
 from .tfpm import nbody, linear_field, lpt_init
-import cosmology
+import flowpm.cosmology as cosmology

--- a/flowpm/cosmology.py
+++ b/flowpm/cosmology.py
@@ -1,0 +1,149 @@
+import tensorflow as tf
+from functools import partial
+
+
+class Cosmology:
+    def __init__(self, Omega_c, Omega_b, h, n_s, sigma8, Omega_k, w0, wa):
+        """
+        Cosmology object, stores primary and derived cosmological parameters.
+        Parameters:
+        -----------
+        Omega_c, float
+          Cold dark matter density fraction.
+        Omega_b, float
+          Baryonic matter density fraction.
+        h, float
+          Hubble constant divided by 100 km/s/Mpc; unitless.
+        n_s, float
+          Primordial scalar perturbation spectral index.
+        sigma8, float
+          Variance of matter density perturbations at an 8 Mpc/h scale
+        Omega_k, float
+          Curvature density fraction.
+        w0, float
+          First order term of dark energy equation
+        wa, float
+          Second order term of dark energy equation of state
+        """
+        # Store primary parameters
+        self._Omega_c = tf.convert_to_tensor(Omega_c, dtype=tf.float32)
+        self._Omega_b = tf.convert_to_tensor(Omega_b, dtype=tf.float32)
+        self._h = tf.convert_to_tensor(h, dtype=tf.float32)
+        self._n_s = tf.convert_to_tensor(n_s, dtype=tf.float32)
+        self._sigma8 = tf.convert_to_tensor(sigma8, dtype=tf.float32)
+        self._Omega_k = tf.convert_to_tensor(Omega_k, dtype=tf.float32)
+        self._w0 = tf.convert_to_tensor(w0, dtype=tf.float32)
+        self._wa = tf.convert_to_tensor(wa, dtype=tf.float32)
+
+        self._flags = {}
+
+        # Create a workspace where functions can store some precomputed
+        # results
+        self._workspace = {}
+
+    def __str__(self):
+        return (
+            "Cosmological parameters: \n"
+            + "    h:        "
+            + str(self.h)
+            + " \n"
+            + "    Omega_b:  "
+            + str(self.Omega_b)
+            + " \n"
+            + "    Omega_c:  "
+            + str(self.Omega_c)
+            + " \n"
+            + "    Omega_k:  "
+            + str(self.Omega_k)
+            + " \n"
+            + "    w0:       "
+            + str(self.w0)
+            + " \n"
+            + "    wa:       "
+            + str(self.wa)
+            + " \n"
+            + "    n:        "
+            + str(self.n_s)
+            + " \n"
+            + "    sigma8:   "
+            + str(self.sigma8)
+        )
+
+    def __repr__(self):
+        return self.__str__()
+
+    # Cosmological parameters, base and derived
+    @property
+    def Omega(self):
+        return 1.0 - self._Omega_k
+
+    @property
+    def Omega_b(self):
+        return self._Omega_b
+
+    @property
+    def Omega_c(self):
+        return self._Omega_c
+
+    @property
+    def Omega_m(self):
+        return self._Omega_b + self._Omega_c
+
+    @property
+    def Omega_de(self):
+        return self.Omega - self.Omega_m
+
+    @property
+    def Omega_k(self):
+        return self._Omega_k
+
+    @property
+    def k(self):
+        if self.Omega > 1.0:  # Closed universe
+            k = 1.0
+        elif self.Omega == 1.0:  # Flat universe
+            k = 0
+        elif self.Omega < 1.0:  # Open Universe
+            k = -1.0
+        return k
+
+    @property
+    def sqrtk(self):
+        return tf.math.sqrt(tf.math.abs(self._Omega_k))
+
+    @property
+    def h(self):
+        return self._h
+
+    @property
+    def w0(self):
+        return self._w0
+
+    @property
+    def wa(self):
+        return self._wa
+
+    @property
+    def n_s(self):
+        return self._n_s
+
+    @property
+    def sigma8(self):
+        return self._sigma8
+
+
+# To add new cosmologies, we just set the parameters to some default values
+# using partial
+
+# Planck 2015 paper XII Table 4 final column (best fit)
+Planck15 = partial(
+    Cosmology,
+    Omega_c=0.2589,
+    Omega_b=0.04860,
+    Omega_k=0.0,
+    h=0.6774,
+    n_s=0.9667,
+    sigma8=0.8159,
+    w0=-1.0,
+    wa=0.0,
+)

--- a/flowpm/cosmology.py
+++ b/flowpm/cosmology.py
@@ -41,6 +41,16 @@ class Cosmology:
         # results
         self._workspace = {}
 
+    def to_dict(self):
+        return {'Omega_c': self.Omega_c,
+                'Omega_b': self.Omega_b,
+                'h': self.h,
+                'n_s': self.n_s,
+                'sigma8': self.sigma8,
+                'Omega_k': self.Omega_k,
+                'w0': self.w0,
+                'wa': self.wa}
+
     def __str__(self):
         return (
             "Cosmological parameters: \n"

--- a/flowpm/tfbackground.py
+++ b/flowpm/tfbackground.py
@@ -584,7 +584,7 @@ def maybe_compute_ODE(cosmo, log10_amin=-2, steps=1024):
     # Otherwise, we compute it now, and save the results for later
     a = tf.convert_to_tensor(np.logspace(log10_amin, 0., steps),
                              dtype=tf.float32)
-    cache = odesolve_func(a, cosmo.to_dict())
+    cache = odesolve_func(a, **cosmo.to_dict())
     cosmo._workspace['cache_ODE'] = cache
   return cache
 

--- a/flowpm/tfbackground.py
+++ b/flowpm/tfbackground.py
@@ -546,7 +546,7 @@ def odesolve_func(a, rtol=1e-4, **kwcosmo):
                          constants=kwcosmo)
 
   # While we are at it, compute second order derivatives growth
-  second_order_results = growth_ode(results.times, results.states, kwcosmo)
+  second_order_results = growth_ode(results.times, results.states, **kwcosmo)
 
   # Normalize the ODE to present time
   # For first order growth and its derivative

--- a/flowpm/tfbackground.py
+++ b/flowpm/tfbackground.py
@@ -5,21 +5,6 @@ import tensorflow_probability as tfp
 import flowpm.constants as constants
 from flowpm.scipy.interpolate import interp_tf
 
-# Planck 2015 results
-cosmo = {
-    "w0": -1.0,
-    "wa": 0.0,
-    "H0": 100,
-    "h": 0.6774,
-    "Omega0_b": 0.04860,
-    "Omega0_c": 0.2589,
-    "Omega0_m": 0.3075,
-    "Omega0_k": 0.0,
-    "Omega0_de": 0.6925,
-    "n_s": 0.9667,
-    "sigma8": 0.8159
-}
-
 
 def fde(cosmo, a, epsilon=1e-5):
   r"""Evolution parameter for the Dark Energy density.
@@ -61,9 +46,7 @@ def fde(cosmo, a, epsilon=1e-5):
         f(a) = -3(1 + w_0) + 3 w \left[ \frac{a - 1}{ \ln(a) } - 1 \right]
     """
   a = tf.convert_to_tensor(a, dtype=tf.float32)
-  w0 = tf.convert_to_tensor(cosmo["w0"], dtype=tf.float32)
-  wa = tf.convert_to_tensor(cosmo["wa"], dtype=tf.float32)
-  return (-3.0 * (1.0 + w0) + 3.0 * wa *
+  return (-3.0 * (1.0 + cosmo.w0) + 3.0 * cosmo.wa *
           ((a - 1.0) / tf.math.log(a - epsilon) - 1.0))
 
 
@@ -96,9 +79,7 @@ def w(cosmo, a):
         w(a) = w_0 + w (1 -a)
   """
   a = tf.convert_to_tensor(a, dtype=tf.float32)
-  w0 = tf.convert_to_tensor(cosmo["w0"], dtype=tf.float32)
-  wa = tf.convert_to_tensor(cosmo["wa"], dtype=tf.float32)
-  return w0 + wa * (1.0 - a)
+  return cosmo.w0 + cosmo.wa * (1.0 - a)
 
 
 def E(cosmo, a):
@@ -134,9 +115,9 @@ def E(cosmo, a):
     by :py:meth:`.f_de`.
     """
   a = tf.convert_to_tensor(a, dtype=tf.float32)
-  return (tf.math.sqrt(cosmo["Omega0_m"] / tf.math.pow(a, 3) +
-                       cosmo["Omega0_k"] / tf.math.pow(a, 2) +
-                       cosmo["Omega0_de"] * tf.math.pow(a, fde(cosmo, a))))
+  return (tf.math.sqrt(cosmo.Omega0_m / tf.math.pow(a, 3) +
+                       cosmo.Omega0_k / tf.math.pow(a, 2) +
+                       cosmo.Omega0_de * tf.math.pow(a, fde(cosmo, a))))
 
 
 def H(cosmo, a):
@@ -156,7 +137,7 @@ def H(cosmo, a):
         Hubble parameter at the requested scale factor.
     """
   a = tf.convert_to_tensor(a, dtype=tf.float32)
-  return constants.H0 * cosmo["h"] * (E(cosmo, a))
+  return constants.H0 * cosmo.h * (E(cosmo, a))
 
 
 def dfde(cosmo, a, epsilon=1e-5):
@@ -191,8 +172,7 @@ def dfde(cosmo, a, epsilon=1e-5):
     \frac{a-1}{a-\epsilon}\right)}{\ln^2(a-\epsilon)}
     """
   a = tf.convert_to_tensor(a, dtype=tf.float32)
-  wa = tf.convert_to_tensor(cosmo["wa"], dtype=tf.float32)
-  return (3 * wa * (tf.math.log(a - epsilon) - (a - 1) / (a - epsilon)) /
+  return (3 * cosmo.wa * (tf.math.log(a - epsilon) - (a - 1) / (a - epsilon)) /
           tf.math.pow(tf.math.log(a - epsilon), 2))
 
 
@@ -227,9 +207,9 @@ def dEa(cosmo, a):
         +f'_{de}\Omega_{0de}a^{f_{de}(a)}}{2E(a)}
     """
   a = tf.convert_to_tensor(a, dtype=tf.float32)
-  return 0.5 * (-3 * cosmo["Omega0_m"] / tf.math.pow(a, 4) -
-                2 * cosmo["Omega0_k"] / tf.math.pow(a, 3) + dfde(cosmo, a) *
-                cosmo["Omega0_de"] * tf.math.pow(a, fde(cosmo, a))) / E(
+  return 0.5 * (-3 * cosmo.Omega0_m / tf.math.pow(a, 4) -
+                2 * cosmo.Omega0_k / tf.math.pow(a, 3) + dfde(cosmo, a) *
+                cosmo.Omega0_de * tf.math.pow(a, fde(cosmo, a))) / E(
                     cosmo, a)
 
 
@@ -260,7 +240,7 @@ def Omega_m_a(cosmo, a):
     see :cite:`2005:Percival` Eq. (6)
     """
   a = tf.convert_to_tensor(a, dtype=tf.float32)
-  return cosmo["Omega0_m"] * tf.math.pow(a, -3) / E(cosmo, a)**2
+  return cosmo.Omega0_m * tf.math.pow(a, -3) / E(cosmo, a)**2
 
 
 def Omega_de_a(cosmo, a):
@@ -292,7 +272,7 @@ def Omega_de_a(cosmo, a):
     :py:meth:`.f_de` (see :cite:`2005:Percival` Eq. (6)).
     """
   a = tf.convert_to_tensor(a, dtype=tf.float32)
-  return cosmo["Omega0_de"] * tf.math.pow(a, fde(cosmo, a)) / E(cosmo, a)**2
+  return cosmo.Omega0_de * tf.math.pow(a, fde(cosmo, a)) / E(cosmo, a)**2
 
 
 def dchioverda(cosmo, a):
@@ -361,7 +341,7 @@ def rad_comoving_distance(cosmo, a, log10_amin=-3, steps=256, rtol=1e-3):
 
         \chi(a) =  R_H \int_a^1 \frac{da^\prime}{{a^\prime}^2 E(a^\prime)}
     """
-  if "background.radial_comoving_distance" not in cosmo.keys():
+  if "background.radial_comoving_distance" not in cosmo._workspace.keys():
     atab = np.logspace(log10_amin, 0.0, steps)
 
     def dchioverdlna(x, y):
@@ -375,9 +355,9 @@ def rad_comoving_distance(cosmo, a, log10_amin=-3, steps=256, rtol=1e-3):
     chitab = tf.convert_to_tensor(chitab, dtype=tf.float32)
     atab = tf.convert_to_tensor(atab, dtype=tf.float32)
     cache = {"a": atab, "chi": chitab}
-    cosmo["tfbackground.radial_comoving_distance"] = cache
+    cosmo._workspace["tfbackground.radial_comoving_distance"] = cache
   else:
-    cache = cosmo["background.radial_comoving_distance"]
+    cache = cosmo._workspace["background.radial_comoving_distance"]
   # Return the results as an interpolation of the table)
   lna = tf.math.log(a)
   inter = tfp.math.interp_regular_1d_grid(tf.cast(lna, dtype=tf.float32),
@@ -405,9 +385,9 @@ def a_of_chi(cosmo, chi):
       Scale factors corresponding to requested distances
     """
   # Check if distances have already been computed, force computation otherwise
-  if "background.radial_comoving_distance" not in cosmo.keys():
+  if "background.radial_comoving_distance" not in cosmo._workspace.keys():
     rad_comoving_distance(cosmo, 1.0)
-  cache = cosmo["tfbackground.radial_comoving_distance"]
+  cache = cosmo._workspace["tfbackground.radial_comoving_distance"]
   chi = tf.cast(chi, dtype=tf.float32)
   return interp_tf(chi, cache["chi"], cache["a"])
 
@@ -448,11 +428,11 @@ def transverse_comoving_distance(cosmo, a):
         \right.
     """
   chi = rad_comoving_distance(cosmo, a)
-  if cosmo['Omega0_k'] < 0:  # Open universe
-    return constants.rh / tf.math.sqrt(cosmo['Omega0_k']) * tf.math.sinh(
+  if cosmo.Omega0_k < 0:  # Open universe
+    return constants.rh / tf.math.sqrt(cosmo.Omega0_k) * tf.math.sinh(
         cosmo.sqrtk * chi / constants.rh)
-  elif cosmo['Omega0_k'] > 0:  # Closed Universe
-    return constants.rh / tf.math.sqrt(cosmo['Omega0_k']) * tf.math.sin(
+  elif cosmo.Omega0_k > 0:  # Closed Universe
+    return constants.rh / tf.math.sqrt(cosmo.Omega0_k) * tf.math.sin(
         cosmo.sqrtk * chi / constants.rh)
   else:
     return chi
@@ -591,10 +571,10 @@ def maybe_compute_ODE(cosmo, log10_amin=-2, steps=1024):
   """
     Either computes or returns the cached ODE solution
     """
-  if 'cache_ODE' in cosmo:
+  if 'cache_ODE' in cosmo._workspace:
     # If cache is found in the cosmo dictionary it means the ODE has already
     # been computed
-    cache = cosmo['cache_ODE']
+    cache = cosmo._workspace['cache_ODE']
     # Checking that the stored ODE results have the right lenght
     assert len(cache['a']) == steps
   else:
@@ -602,11 +582,10 @@ def maybe_compute_ODE(cosmo, log10_amin=-2, steps=1024):
     a = tf.convert_to_tensor(np.logspace(log10_amin, 0., steps),
                              dtype=tf.float32)
     cache = odesolve_func(cosmo, a)
-    cosmo['cache_ODE'] = cache
+    cosmo._workspace['cache_ODE'] = cache
   return cache
 
 
-################################################################
 def D1(cosmo, a):
   """ Normalised first order growth factor.
 
@@ -673,9 +652,6 @@ def D2(cosmo, a):
   return tfp.math.interp_regular_1d_grid(lna, tf.math.log(cache['a'][0]),
                                          tf.math.log(cache['a'][-1]),
                                          cache['D2'])
-
-
-#################################################################
 
 
 def D1f(cosmo, a):
@@ -808,7 +784,6 @@ def f2(cosmo, a):
   return D2f(cosmo, a) * a / D2(cosmo, a)
 
 
-################################################################
 def Gf(cosmo, a):
   """
     FastPM growth factor function
@@ -863,9 +838,6 @@ def Gf2(cosmo, a):
     """
   a = tf.convert_to_tensor(a, dtype=tf.float32)
   return D2f(cosmo, a) * a**3 * E(cosmo, a)
-
-
-################################################################
 
 
 def gf(cosmo, a):
@@ -946,29 +918,3 @@ def gf2(cosmo, a):
                                         cache['F2p'])
   return (f2p * a**3 * E(cosmo, a) + d2f * a**3 * dEa(cosmo, a) +
           3 * a**2 * E(cosmo, a) * d2f)
-
-
-#
-# if __name__ == "__main__":
-#   """ Tests implementation and draws first and second order growth.
-#   """
-#   import matplotlib.pyplot as plt
-#   log10_amin=-2
-#   steps=128
-#   atab =np.logspace(log10_amin, 0.0, steps)
-#   y0=tf.constant([[atab[0], -3./7 * 0.01**2], [1.0, -6. / 7 *0.01]],dtype=tf.float32)
-#
-#   results_func=odesolve_func(atab,y0)
-#
-#   #normalise D1 and D2 such that D1(a=1) = 1 and D2(a=1) = 1
-#   D1_norm=results_func.states[:,0,0]/results_func.states[-1,0,0]
-#   D2_norm=results_func.states[:,0,1]/results_func.states[-1,0,1]
-#   d1_fn=results_func.states[:,1,0]/results_func.states[-1,0,0]
-#   d2_fn=results_func.states[:,1,1]/results_func.states[-1,0,1]
-#
-#   plt.plot(results_func.times,D1_norm,label='$D_1$')
-#   plt.plot(results_func.times,D2_norm,label='$D_2$')
-#   plt.xlabel('Scale factor')
-#   plt.ylabel('Growth function')
-#   plt.legend()
-#   plt.show()

--- a/flowpm/tfbackground.py
+++ b/flowpm/tfbackground.py
@@ -509,7 +509,6 @@ def growth_ode(a, y, **kwcosmo):
   return dydt
 
 
-@tf.function
 def odesolve_func(a, rtol=1e-4, **kwcosmo):
   """ Solves the growth ODE system for a given cosmology at the requested
     scale factors.

--- a/flowpm/tfbackground.py
+++ b/flowpm/tfbackground.py
@@ -115,9 +115,9 @@ def E(cosmo, a):
     by :py:meth:`.f_de`.
     """
   a = tf.convert_to_tensor(a, dtype=tf.float32)
-  return (tf.math.sqrt(cosmo.Omega0_m / tf.math.pow(a, 3) +
-                       cosmo.Omega0_k / tf.math.pow(a, 2) +
-                       cosmo.Omega0_de * tf.math.pow(a, fde(cosmo, a))))
+  return (tf.math.sqrt(cosmo.Omega_m / tf.math.pow(a, 3) +
+                       cosmo.Omega_k / tf.math.pow(a, 2) +
+                       cosmo.Omega_de * tf.math.pow(a, fde(cosmo, a))))
 
 
 def H(cosmo, a):
@@ -207,9 +207,9 @@ def dEa(cosmo, a):
         +f'_{de}\Omega_{0de}a^{f_{de}(a)}}{2E(a)}
     """
   a = tf.convert_to_tensor(a, dtype=tf.float32)
-  return 0.5 * (-3 * cosmo.Omega0_m / tf.math.pow(a, 4) -
-                2 * cosmo.Omega0_k / tf.math.pow(a, 3) + dfde(cosmo, a) *
-                cosmo.Omega0_de * tf.math.pow(a, fde(cosmo, a))) / E(
+  return 0.5 * (-3 * cosmo.Omega_m / tf.math.pow(a, 4) -
+                2 * cosmo.Omega_k / tf.math.pow(a, 3) + dfde(cosmo, a) *
+                cosmo.Omega_de * tf.math.pow(a, fde(cosmo, a))) / E(
                     cosmo, a)
 
 
@@ -240,7 +240,7 @@ def Omega_m_a(cosmo, a):
     see :cite:`2005:Percival` Eq. (6)
     """
   a = tf.convert_to_tensor(a, dtype=tf.float32)
-  return cosmo.Omega0_m * tf.math.pow(a, -3) / E(cosmo, a)**2
+  return cosmo.Omega_m * tf.math.pow(a, -3) / E(cosmo, a)**2
 
 
 def Omega_de_a(cosmo, a):
@@ -272,7 +272,7 @@ def Omega_de_a(cosmo, a):
     :py:meth:`.f_de` (see :cite:`2005:Percival` Eq. (6)).
     """
   a = tf.convert_to_tensor(a, dtype=tf.float32)
-  return cosmo.Omega0_de * tf.math.pow(a, fde(cosmo, a)) / E(cosmo, a)**2
+  return cosmo.Omega_de * tf.math.pow(a, fde(cosmo, a)) / E(cosmo, a)**2
 
 
 def dchioverda(cosmo, a):
@@ -428,11 +428,11 @@ def transverse_comoving_distance(cosmo, a):
         \right.
     """
   chi = rad_comoving_distance(cosmo, a)
-  if cosmo.Omega0_k < 0:  # Open universe
-    return constants.rh / tf.math.sqrt(cosmo.Omega0_k) * tf.math.sinh(
+  if cosmo.Omega_k < 0:  # Open universe
+    return constants.rh / tf.math.sqrt(cosmo.Omega_k) * tf.math.sinh(
         cosmo.sqrtk * chi / constants.rh)
-  elif cosmo.Omega0_k > 0:  # Closed Universe
-    return constants.rh / tf.math.sqrt(cosmo.Omega0_k) * tf.math.sin(
+  elif cosmo.Omega_k > 0:  # Closed Universe
+    return constants.rh / tf.math.sqrt(cosmo.Omega_k) * tf.math.sin(
         cosmo.sqrtk * chi / constants.rh)
   else:
     return chi

--- a/flowpm/tfpm.py
+++ b/flowpm/tfpm.py
@@ -326,7 +326,7 @@ def force(cosmo, state,
     rho = tf.multiply(rho,
                       1. / nbar)  # I am not sure why this is not needed here
     delta_k = r2c3d(rho, norm=ncf[0] * ncf[1] * ncf[2])
-    fac = tf.cast(1.5 * cosmo.Omega0_m, dtype=dtype)
+    fac = tf.cast(1.5 * cosmo.Omega_m, dtype=dtype)
     update = apply_longrange(tf.multiply(state[0], pm_nc_factor),
                              delta_k,
                              split=0,

--- a/flowpm/tfpm.py
+++ b/flowpm/tfpm.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 
 import numpy as np
 import tensorflow as tf
-from flowpm.tfbackground import f1, E, f2, Gf, gf, gf2, D1, D2, cosmo, D1f
+from flowpm.tfbackground import f1, E, f2, Gf, gf, gf2, D1, D2, D1f
 from flowpm.utils import white_noise, c2r3d, r2c3d, cic_paint, cic_readout
 from flowpm.kernels import fftk, laplace_kernel, gradient_kernel, longrange_kernel
 __all__ = ['linear_field', 'lpt_init', 'nbody']
@@ -155,7 +155,7 @@ def lpt2_source(dlin_k, kvec=None, name="LPT2Source"):
     return r2c3d(source, norm=nc[0] * nc[1] * nc[2])
 
 
-def lpt_init(linear, a, order=2, cosmology=cosmo, kvec=None, name="LPTInit"):
+def lpt_init(cosmo, linear, a, order=2, kvec=None, name="LPTInit"):
   """ Estimate the initial LPT displacement given an input linear (real) field
 
   Parameters:
@@ -230,11 +230,7 @@ def apply_longrange(x,
     return f
 
 
-def kick(state,
-         ai,
-         ac,
-         af,
-         cosmology=cosmo,
+def kick(cosmo, state, ai, ac, af,
          dtype=tf.float32,
          name="Kick",
          **kwargs):
@@ -261,11 +257,10 @@ def kick(state,
     return state
 
 
-def drift(state,
+def drift(cosmo, state,
           ai,
           ac,
           af,
-          cosmology=cosmo,
           dtype=tf.float32,
           name="Drift",
           **kwargs):
@@ -292,9 +287,8 @@ def drift(state,
     return state
 
 
-def force(state,
+def force(cosmo, state,
           nc,
-          cosmology=cosmo,
           pm_nc_factor=1,
           kvec=None,
           dtype=tf.float32,
@@ -332,7 +326,7 @@ def force(state,
     rho = tf.multiply(rho,
                       1. / nbar)  # I am not sure why this is not needed here
     delta_k = r2c3d(rho, norm=ncf[0] * ncf[1] * ncf[2])
-    fac = tf.cast(1.5 * cosmology['Omega0_m'], dtype=dtype)
+    fac = tf.cast(1.5 * cosmo.Omega0_m, dtype=dtype)
     update = apply_longrange(tf.multiply(state[0], pm_nc_factor),
                              delta_k,
                              split=0,
@@ -351,12 +345,15 @@ def force(state,
     return state
 
 
-def nbody(state, stages, nc, cosmology=cosmo, pm_nc_factor=1, name="NBody"):
+def nbody(cosmo, state, stages, nc, pm_nc_factor=1, name="NBody"):
   """
   Integrate the evolution of the state across the givent stages
 
   Parameters:
   -----------
+  cosmo: cosmology
+    Cosmological parameter object
+
   state: tensor (3, batch_size, npart, 3)
     Input state
 
@@ -377,7 +374,6 @@ def nbody(state, stages, nc, cosmology=cosmo, pm_nc_factor=1, name="NBody"):
   with tf.name_scope(name):
     state = tf.convert_to_tensor(state, name="state")
 
-    shape = state.get_shape()
     if isinstance(nc, int):
       nc = [nc, nc, nc]
 
@@ -388,7 +384,7 @@ def nbody(state, stages, nc, cosmology=cosmo, pm_nc_factor=1, name="NBody"):
     ai = stages[0]
 
     # first force calculation for jump starting
-    state = force(state, nc, pm_nc_factor=pm_nc_factor, cosmology=cosmology)
+    state = force(cosmo, state, nc, pm_nc_factor=pm_nc_factor)
 
     x, p, f = ai, ai, ai
     # Loop through the stages
@@ -398,19 +394,19 @@ def nbody(state, stages, nc, cosmology=cosmo, pm_nc_factor=1, name="NBody"):
       ah = (a0 * a1)**0.5
 
       # Kick step
-      state = kick(state, p, f, ah, cosmology=cosmology)
+      state = kick(cosmo, state, p, f, ah)
       p = ah
 
       # Drift step
-      state = drift(state, x, p, a1, cosmology=cosmology)
+      state = drift(cosmo, state, x, p, a1)
       x = a1
 
       # Force
-      state = force(state, nc, pm_nc_factor=pm_nc_factor, cosmology=cosmology)
+      state = force(cosmo, state, nc, pm_nc_factor=pm_nc_factor)
       f = a1
 
       # Kick again
-      state = kick(state, p, f, a1, cosmology=cosmology)
+      state = kick(cosmo, state, p, f, a1)
       p = a1
 
     return state

--- a/flowpm/tfpower.py
+++ b/flowpm/tfpower.py
@@ -59,10 +59,10 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_osc"):
   #            - k_silk : Silk damping scale
   T_2_7_sqr = (const.tcmb / 2.7)**2
   h2 = cosmo.h**2
-  w_m = cosmo.Omega0_m * h2
-  w_b = cosmo.Omega0_b * h2
-  fb = cosmo.Omega0_b / cosmo.Omega0_m
-  fc = (cosmo.Omega0_m - cosmo.Omega0_b) / cosmo.Omega0_m
+  w_m = cosmo.Omega_m * h2
+  w_b = cosmo.Omega_b * h2
+  fb = cosmo.Omega_b / cosmo.Omega_m
+  fc = (cosmo.Omega_m - cosmo.Omega_b) / cosmo.Omega_m
 
   k_eq = 7.46e-2 * w_m / T_2_7_sqr / cosmo.h  # Eq. (3) [h/Mpc]
   z_eq = 2.50e4 * w_m / (T_2_7_sqr)**2  # Eq. (2)
@@ -90,8 +90,8 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_osc"):
 
   alpha_gamma = (1.0 - 0.328 * tf.math.log(431.0 * w_m) * w_b / w_m +
                  0.38 * tf.math.log(22.3 * w_m) *
-                 (cosmo.Omega0_b / cosmo.Omega0_m)**2)
-  gamma_eff = (cosmo.Omega0_m * cosmo.h *
+                 (cosmo.Omega_b / cosmo.Omega_m)**2)
+  gamma_eff = (cosmo.Omega_m * cosmo.h *
                (alpha_gamma + (1.0 - alpha_gamma) / (1.0 +
                                                      (0.43 * k * sh_d)**4)))
 

--- a/flowpm/tfpower.py
+++ b/flowpm/tfpower.py
@@ -85,7 +85,7 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_osc"):
       (1.0 + tf.math.sqrt(R_eq))))
   # Eq. (7) but in [hMpc^{-1}]
   k_silk = (1.6 * tf.math.pow(w_b, 0.52) * tf.math.pow(w_m, 0.73) *
-            (1.0 + tf.math.pow(10.4 * w_m, -0.95)) / cosmo["h"])
+            (1.0 + tf.math.pow(10.4 * w_m, -0.95)) / cosmo.h)
   #############################################
 
   alpha_gamma = (1.0 - 0.328 * tf.math.log(431.0 * w_m) * w_b / w_m +

--- a/flowpm/tfpower.py
+++ b/flowpm/tfpower.py
@@ -22,7 +22,7 @@ def primordial_matter_power(cosmo, k):
       Primordial power spectrum  evaluated at requested scales
     """
   k = tf.convert_to_tensor(k, dtype=tf.float32)
-  return k**cosmo['n_s']
+  return k**cosmo.n_s
 
 
 def Eisenstein_Hu(cosmo, k, type="eisenhu_osc"):
@@ -58,13 +58,13 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_osc"):
   #            - sh_d   : sound horizon at drag epoch
   #            - k_silk : Silk damping scale
   T_2_7_sqr = (const.tcmb / 2.7)**2
-  h2 = cosmo["h"]**2
-  w_m = cosmo["Omega0_m"] * h2
-  w_b = cosmo["Omega0_b"] * h2
-  fb = cosmo["Omega0_b"] / cosmo["Omega0_m"]
-  fc = (cosmo["Omega0_m"] - cosmo["Omega0_b"]) / cosmo["Omega0_m"]
+  h2 = cosmo.h**2
+  w_m = cosmo.Omega0_m * h2
+  w_b = cosmo.Omega0_b * h2
+  fb = cosmo.Omega0_b / cosmo.Omega0_m
+  fc = (cosmo.Omega0_m - cosmo.Omega0_b) / cosmo.Omega0_m
 
-  k_eq = 7.46e-2 * w_m / T_2_7_sqr / cosmo["h"]  # Eq. (3) [h/Mpc]
+  k_eq = 7.46e-2 * w_m / T_2_7_sqr / cosmo.h  # Eq. (3) [h/Mpc]
   z_eq = 2.50e4 * w_m / (T_2_7_sqr)**2  # Eq. (2)
 
   # z drag from Eq. (4)
@@ -90,8 +90,8 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_osc"):
 
   alpha_gamma = (1.0 - 0.328 * tf.math.log(431.0 * w_m) * w_b / w_m +
                  0.38 * tf.math.log(22.3 * w_m) *
-                 (cosmo["Omega0_b"] / cosmo["Omega0_m"])**2)
-  gamma_eff = (cosmo["Omega0_m"] * cosmo["h"] *
+                 (cosmo.Omega0_b / cosmo.Omega0_m)**2)
+  gamma_eff = (cosmo.Omega0_m * cosmo.h *
                (alpha_gamma + (1.0 - alpha_gamma) / (1.0 +
                                                      (0.43 * k * sh_d)**4)))
 
@@ -181,7 +181,7 @@ def linear_matter_power(cosmo, k, a=1.0, transfer_fn=Eisenstein_Hu, **kwargs):
   g = bkgrd.D1(cosmo, a)
   t = transfer_fn(cosmo, k, **kwargs)
 
-  pknorm = cosmo["sigma8"]**2 / sigmasqr(cosmo, 8.0, transfer_fn, **kwargs)
+  pknorm = cosmo.sigma8**2 / sigmasqr(cosmo, 8.0, transfer_fn, **kwargs)
 
   pk = primordial_matter_power(cosmo, k) * t**2 * g**2
 

--- a/tests/test_distancefunctions.py
+++ b/tests/test_distancefunctions.py
@@ -15,7 +15,6 @@ from nbodykit.cosmology import Cosmology
 from astropy.cosmology import Planck15
 import astropy.units as u
 
-
 # Create a simple Planck15 cosmology without neutrinos, and makes sure sigma8
 # is matched
 ref_cosmo = Cosmology.from_astropy(Planck15.clone(m_nu=0 * u.eV))

--- a/tests/test_distancefunctions.py
+++ b/tests/test_distancefunctions.py
@@ -103,14 +103,7 @@ def test_a_of_chi():
   """This function test the function computing the scale factor for corresponding (array) of radial comoving
     distance by reverse linear interpolation
   """
-  cosmo_tf = flowpm.cosmology.Cosmology(Omega_c=cosmo.Omega0_cdm,
-                                     Omega_b=cosmo.Omega0_b,
-                                     Omega_k=0.0,
-                                     h=cosmo.h,
-                                     n_s=cosmo.n_s,
-                                     sigma8=cosmo.sigma8,
-                                     w0=-1.,
-                                     wa=0.0)
+  cosmo_tf = flowpm.cosmology.Planck15()
 
   a = np.logspace(-2, 0.0, 512)
 

--- a/tests/test_distancefunctions.py
+++ b/tests/test_distancefunctions.py
@@ -94,7 +94,14 @@ def test_a_of_chi():
   """This function test the function computing the scale factor for corresponding (array) of radial comoving
     distance by reverse linear interpolation
   """
-  cosmo_tf = flowpm.cosmology.Planck15()
+  cosmo_tf = flowpm.cosmology.Cosmology(Omega_c=cosmo.Omega0_cdm,
+                                     Omega_b=cosmo.Omega0_b,
+                                     Omega_k=0.0,
+                                     h=cosmo.h,
+                                     n_s=cosmo.n_s,
+                                     sigma8=cosmo.sigma8,
+                                     w0=-1.,
+                                     wa=0.0)
 
   a = np.logspace(-2, 0.0, 512)
 

--- a/tests/test_distancefunctions.py
+++ b/tests/test_distancefunctions.py
@@ -7,33 +7,22 @@ Created on Wed Dec  2 18:24:41 2020
 """
 
 import numpy as np
+import flowpm
 from flowpm.tfbackground import dchioverda, rad_comoving_distance, a_of_chi as a_of_chi_tf, transverse_comoving_distance as trans_comoving_distance, angular_diameter_distance as ang_diameter_distance
 from numpy.testing import assert_allclose
-
+from scipy import interpolate
 from nbodykit.cosmology import Planck15 as cosmo
-cosmo1 = {
-    "w0": -1.0,
-    "wa": 0.0,
-    "H0": 100,
-    "h": cosmo.h,
-    "Omega0_b": cosmo.Omega0_b,
-    "Omega0_c": cosmo.Omega0_cdm,
-    "Omega0_m": cosmo.Omega0_m,
-    "Omega0_k": 0.0,
-    "Omega0_de": cosmo.Omega0_lambda,
-    "n_s": cosmo.n_s,
-    "sigma8": cosmo.sigma8
-}
 
 
 def test_radial_comoving_distance():
   """ This function tests the function computing the radial comoving distance.
-    """
+  """
+  cosmo_tf = flowpm.cosmology.Planck15()
   a = np.logspace(-2, 0.0)
 
   z = 1 / a - 1
 
-  radial = rad_comoving_distance(cosmo1, a)
+  radial = rad_comoving_distance(cosmo_tf, a)
 
   radial_astr = cosmo.comoving_distance(z)
 
@@ -42,12 +31,13 @@ def test_radial_comoving_distance():
 
 def test_transverse_comoving_distance():
   """This function test the function computing the Transverse comoving distance in [Mpc/h] for a given scale factor
-      """
+  """
+  cosmo_tf = flowpm.cosmology.Planck15()
   a = np.logspace(-2, 0.0)
 
   z = 1 / a - 1
 
-  trans_tf = trans_comoving_distance(cosmo1, a)
+  trans_tf = trans_comoving_distance(cosmo_tf, a)
 
   trans_astr = cosmo.comoving_transverse_distance(z)
 
@@ -56,7 +46,8 @@ def test_transverse_comoving_distance():
 
 def test_angular_diameter_distance():
   """This function test the function computing the  Angular diameter distance in [Mpc/h] for a given scale factor
-      """
+  """
+  cosmo_tf = flowpm.cosmology.Planck15()
 
   a = np.logspace(-2, 0.0)
 
@@ -64,7 +55,7 @@ def test_angular_diameter_distance():
 
   angular_diameter_distance_astr = cosmo.angular_diameter_distance(z)
 
-  angular_diameter_distance_tf = ang_diameter_distance(cosmo1, a)
+  angular_diameter_distance_tf = ang_diameter_distance(cosmo_tf, a)
 
   assert_allclose(angular_diameter_distance_tf,
                   angular_diameter_distance_astr,
@@ -76,8 +67,6 @@ def test_angular_diameter_distance():
 # build a new a-of-chi function by interpolation using a scipy interpolation function.
 # Then we compare thiss function with our a-of-chi function.
 # =============================================================================
-from scipy import interpolate
-
 
 def a_of_chi(z):
   r"""Computes the scale factor for corresponding (array) of radial comoving
@@ -104,7 +93,8 @@ def a_of_chi(z):
 def test_a_of_chi():
   """This function test the function computing the scale factor for corresponding (array) of radial comoving
     distance by reverse linear interpolation
-      """
+  """
+  cosmo_tf = flowpm.cosmology.Planck15()
 
   a = np.logspace(-2, 0.0, 512)
 
@@ -112,7 +102,7 @@ def test_a_of_chi():
 
   chi = np.geomspace(500, 8000, 50)
 
-  aofchi_tf = a_of_chi_tf(cosmo1, chi)
+  aofchi_tf = a_of_chi_tf(cosmo_tf, chi)
 
   f = a_of_chi(z)
 

--- a/tests/test_tfbackground.py
+++ b/tests/test_tfbackground.py
@@ -1,22 +1,9 @@
 import tensorflow as tf
 import numpy as np
+import flowpm
 from flowpm.tfbackground import dEa, Omega_m_a, E, Gf, Gf2, gf, gf2, D1, D2, D1f, D2f, f1, f2
 from numpy.testing import assert_allclose
 from flowpm.legacy_background import MatterDominated
-
-cosmo = {
-    "w0": -1.0,
-    "wa": 0.0,
-    "H0": 100,
-    "h": 0.6774,
-    "Omega0_b": 0.04860,
-    "Omega0_c": 0.2589,
-    "Omega0_m": 0.3075,
-    "Omega0_k": 0.0,
-    "Omega0_de": 0.6925,
-    "n_s": 0.9667,
-    "sigma8": 0.8159
-}
 
 
 def test_E():
@@ -24,6 +11,8 @@ def test_E():
     Hubble parameter.
     """
   M_d = MatterDominated(Omega0_m=0.3075)
+  cosmo = flowpm.cosmology.Planck15()
+
   a = np.logspace(-3, 0)
   # Computing reference E value with old code
   E_ref = M_d.E(a)
@@ -37,6 +26,8 @@ def test_Eprime():
   """ Testing Derivative of the scale factor dependent factor E(a)
   """
   M_d = MatterDominated(Omega0_m=0.3075)
+  cosmo = flowpm.cosmology.Planck15()
+
   a = np.logspace(-3, 0)
   # Computing reference E' value with old code
   E_prim_back = M_d.efunc_prime(a)
@@ -50,6 +41,8 @@ def test_Omega_m():
   """ Testing Matter density at scale factor `a`
   """
   M_d = MatterDominated(Omega0_m=0.3075)
+  cosmo = flowpm.cosmology.Planck15()
+
   a = np.logspace(-3, 0)
   # Computing reference Omega_m value with old code
   Omega_back = M_d.Om(a)
@@ -64,6 +57,8 @@ def test_growth_1order():
     """
 
   M_d = MatterDominated(Omega0_m=0.3075)
+  cosmo = flowpm.cosmology.Planck15()
+
   a = np.logspace(-2, 0.0, 128)
   gback = M_d.D1(a)
   gtfback = D1(cosmo, a)
@@ -76,6 +71,8 @@ def test_growth_2order():
     """
 
   M_d = MatterDominated(Omega0_m=0.3075)
+  cosmo = flowpm.cosmology.Planck15()
+
   a = np.logspace(-2, 0.0, 128)
   g2back = M_d.D2(a)
   g2tfback = D2(cosmo, a)
@@ -88,6 +85,8 @@ def test_D1_fnorm():
     """
 
   M_d = MatterDominated(Omega0_m=0.3075)
+  cosmo = flowpm.cosmology.Planck15()
+
   a = np.logspace(-2, 0.0, 128)
   gback = M_d.gp(a)
   gtfback = D1f(cosmo, a)
@@ -100,6 +99,8 @@ def test_D2_fnorm():
     """
 
   M_d = MatterDominated(Omega0_m=0.3075)
+  cosmo = flowpm.cosmology.Planck15()
+
   a = np.logspace(-2, 0.0, 128)
   g2back = M_d.gp2(a)
   g2tfback = D2f(cosmo, a)
@@ -110,6 +111,8 @@ def test_D2_fnorm():
 # =============================================================================
 def testf1():
   M_d = MatterDominated(Omega0_m=0.3075)
+  cosmo = flowpm.cosmology.Planck15()
+
   a = np.logspace(-2, 0, 128)
   f1_back = M_d.f1(a)
   f1_tf = f1(cosmo, a)
@@ -119,6 +122,8 @@ def testf1():
 
 def testf2():
   M_d = MatterDominated(Omega0_m=0.3075)
+  cosmo = flowpm.cosmology.Planck15()
+
   a = np.logspace(-2, 0, 128)
   f2_back = M_d.f2(a)
   f2_tf = f2(cosmo, a)
@@ -128,6 +133,8 @@ def testf2():
 
 def testGf():
   M_d = MatterDominated(Omega0_m=0.3075)
+  cosmo = flowpm.cosmology.Planck15()
+
   a = np.logspace(-2, 0, 128)
   Gf_back = M_d.Gf(a)
   Gf_tf = Gf(cosmo, a)
@@ -137,6 +144,8 @@ def testGf():
 
 def testGf2():
   M_d = MatterDominated(Omega0_m=0.3075)
+  cosmo = flowpm.cosmology.Planck15()
+
   a = np.logspace(-2, 0, 128)
   Gf2_back = M_d.Gf2(a)
   Gf2_tf = Gf2(cosmo, a)
@@ -146,6 +155,8 @@ def testGf2():
 
 def testgf():
   M_d = MatterDominated(Omega0_m=0.3075)
+  cosmo = flowpm.cosmology.Planck15()
+
   a = np.logspace(-2, 0, 128)
   gf_back = M_d.gf(a)
   gf_tf = gf(cosmo, a)
@@ -155,6 +166,8 @@ def testgf():
 
 def testgf2():
   M_d = MatterDominated(Omega0_m=0.3075)
+  cosmo = flowpm.cosmology.Planck15()
+
   a = np.logspace(-2, 0, 128)
   gf2_back = M_d.gf2(a)
   gf2_tf = gf2(cosmo, a)

--- a/tests/test_tfpm.py
+++ b/tests/test_tfpm.py
@@ -21,7 +21,6 @@ np.random.seed(0)
 bs = 50
 nc = 16
 
-
 # Create a simple Planck15 cosmology without neutrinos, and makes sure sigma8
 # is matched
 ref_cosmo = Cosmology.from_astropy(Planck15.clone(m_nu=0 * u.eV))

--- a/tests/test_tfpower.py
+++ b/tests/test_tfpower.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_allclose
 def test_eisenstein_hu():
   cosmo = flowpm.cosmology.Cosmology(Omega_c=Planck15.Omega0_cdm,
                                      Omega_b=Planck15.Omega0_b,
-                                     Omega0_k=0.0,
+                                     Omega_k=0.0,
                                      h=Planck15.h,
                                      n_s=Planck15.n_s,
                                      sigma8=Planck15.sigma8,

--- a/tests/test_tfpower.py
+++ b/tests/test_tfpower.py
@@ -1,7 +1,7 @@
 # Tests analytic power spectra computations
 import tensorflow as tf
 import numpy as np
-import flowpm.tfbackground as bkgrd
+import flowpm
 import flowpm.tfpower as power
 from nbodykit.cosmology import Planck15
 from nbodykit.cosmology.power.linear import LinearPower
@@ -10,20 +10,14 @@ from numpy.testing import assert_allclose
 
 
 def test_eisenstein_hu():
-  cosmo = {
-      "w0": -1.0,
-      "wa": 0.0,
-      "H0": 100,
-      "h": Planck15.h,
-      "Omega0_b": Planck15.Omega0_b,
-      "Omega0_c": Planck15.Omega0_cdm,
-      "Omega0_m": Planck15.Omega0_m,
-      "Omega0_k": 0.0,
-      "Omega0_de": Planck15.Omega0_lambda,
-      "n_s": Planck15.n_s,
-      "sigma8": Planck15.sigma8
-  }
-
+  cosmo = flowpm.cosmology.Cosmology(Omega_c=Planck15.Omega0_cdm,
+                                     Omega_b=Planck15.Omega0_b,
+                                     Omega0_k=0.0,
+                                     h=Planck15.h,
+                                     n_s=Planck15.n_s,
+                                     sigma8=Planck15.sigma8,
+                                     w0=-1.,
+                                     wa=0.0)
   # Test array of scales
   k = np.logspace(-3, 1, 512)
 


### PR DESCRIPTION
This PR aims to solve #66 by creating a class that can be used to manipulate cosmological parameters. 

!! Warning !! This introduces a breaking change in the FlowPM API, at the level of the lpt_init and nbody functions, which now take a cosmology object as their first argument. The reason for this is that otherwise, if the cosmology is left implicit in some places, it is very possible that people will end up with different cosmologies in different places of their code.
