### PR TITLE
Fix problem with interpolation of scale factor at chi=0

### DIFF
--- a/flowpm/scipy/interpolate.py
+++ b/flowpm/scipy/interpolate.py
@@ -4,25 +4,25 @@ import tensorflow as tf
 
 
 def interp_tf(x, xp, fp):
-  """Returns the one-dimensional piecewise linear interpolant to a function 
+  """Returns the one-dimensional piecewise linear interpolant to a function
         with given discrete data points (xp, fp), evaluated at x.
-  
+
       Parameters
       ----------
       x: array_like or tf.TensorArray
       The x-coordinates at which to evaluate the interpolated values.
-        
+
       xp: array_like or tf.TensorArray
       The x-coordinates of the data points.
 
       fp: array_like or tf.TensorArray
       The y-coordinates of the data points, same length as xp.
-      
+
       Returns
       -------
       Scalar float Tensor
       The interpolated values, same shape as x.
-  
+
     """
   x = tf.convert_to_tensor(x, dtype=tf.float32)
   xp = tf.convert_to_tensor(xp, dtype=tf.float32)
@@ -40,6 +40,7 @@ def interp_tf(x, xp, fp):
   fp1 = tf.gather(fp, ind + tf.cast(tf.sign(s), dtype=tf.int64)) - fp0
   xp0 = tf.gather(xp, ind)
   xp1 = tf.gather(xp, ind + tf.cast(tf.sign(s), dtype=tf.int64)) - xp0
+  a = tf.where(fp1 == 0., fp1, fp1 / xp1)
   a = (fp1) / (xp1)
   b = fp0 - a * xp0
   return a * x + b

--- a/flowpm/tfbackground.py
+++ b/flowpm/tfbackground.py
@@ -389,7 +389,7 @@ def rad_comoving_distance(cosmo, a, log10_amin=-3, steps=256, rtol=1e-3):
 
     chitab = _distance_computation_func(atab, rtol=rtol, **cosmo.to_dict())
 
-    cache = {"a": atab, "chi": chitab}
+    cache = {"a": atab[::-1], "chi": chitab[::-1]}
     cosmo._workspace["tfbackground.radial_comoving_distance"] = cache
   else:
     cache = cosmo._workspace["background.radial_comoving_distance"]

--- a/tests/test_distancefunctions.py
+++ b/tests/test_distancefunctions.py
@@ -108,7 +108,7 @@ def test_a_of_chi():
 
   z = 1 / a - 1
 
-  chi = np.geomspace(100, 6000, 50)
+  chi = np.geomspace(1., 6000, 50)
 
   aofchi_tf = a_of_chi_tf(cosmo_tf, chi)
 


### PR DESCRIPTION
This small PR solves the problem found by @dlanzieri in #68 .

The problem was at the edge of the array, the interpolation logic doesn't work there. when the requested point was to close to the end, the same point is returned for the left and right interpolation values, which causes delta_x to be 0, and blows up in the computation of the linear scale coefficient.

To avoid this problem going forward, I added this line:
```python
  a = tf.where(fp1 == 0., fp1, fp1 / xp1)
```
which makes sure that the scale coefficient is 0 instead of NaN if we end up in the same situation. I've also reversed the order of the values of `a` and `chi` in the interpolation cache, this helps because the problem happens at one end of the array and not the other.

In terms of tests, we could actually already catch that problem in existing tests, in `test_a_of_chi` in `test_distancefunctions.py`, just needed to look at what happens at very low comoving distances. I changed the range of value tested, which fails in the master branch, but is fixed in this branch.