### PR TITLE
Adds tool to export state vector as a BigFile

### DIFF
--- a/flowpm/io.py
+++ b/flowpm/io.py
@@ -1,0 +1,60 @@
+from bigfile import File
+import tensorflow as tf
+
+
+def save_state(cosmo, state, a, nc, boxsize, filename, attrs={}):
+  """
+  Saves a state vector from a given simulation snapshot.
+
+  Note: This is not exactly fastpm compatible.
+
+  Parameters
+  ----------
+  cosmo: cosmology object
+    Comology used to create the snapshot
+
+  state: Tensor, nbody state
+    State tensor with particle position and speed
+
+  a: float
+    Scale factor of the current state
+
+  nc: list of int
+    Number of cells
+
+  boxsize: list of float
+    Length of the simulation volume
+
+  filename: str
+    Export file name
+  """
+  with File(filename, create=True) as ff:
+    with ff.create('Header') as bb:
+      bb.attrs['NC'] = nc
+      bb.attrs['BoxSize'] = boxsize
+      bb.attrs['OmegaCDM'] = cosmo.Omega_c.numpy()
+      bb.attrs['OmegaB'] = cosmo.Omega_b.numpy()
+      bb.attrs['OmegaK'] = cosmo.Omega_k.numpy()
+      bb.attrs['h'] = cosmo.h.numpy()
+      bb.attrs['Sigma8'] = cosmo.sigma8.numpy()
+      bb.attrs['w0'] = cosmo.w0.numpy()
+      bb.attrs['wa'] = cosmo.wa.numpy()
+      bb.attrs['Time'] = a
+      bb.attrs['M0'] = [1.]  # Hummmm I don't know about this one
+      for key in attrs:
+        try:
+          # best effort
+          bb.attrs[key] = attrs[key]
+        except:
+          pass
+    # Factor to convert speed and position back to Mpc/h
+    scaling_factor = 1. / tf.convert_to_tensor(nc, dtype=tf.float32)
+    scaling_factor = scaling_factor * tf.convert_to_tensor(boxsize,
+                                                           dtype=tf.float32)
+    scaling_factor = tf.reshape(scaling_factor, [1, 3])
+    # Export each batch entry as its own block
+    for i in range(state.shape[1]):
+      ff.create_from_array('%d/Position' % i,
+                           (state[0, i] * scaling_factor).numpy())
+      ff.create_from_array('%d/Velocity' % i,
+                           (state[1, i] * scaling_factor).numpy())

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,63 @@
+import tensorflow as tf
+import tempfile
+import numpy as np
+from scipy.interpolate import InterpolatedUnivariateSpline as iuspline
+from numpy.testing import assert_allclose
+import flowpm
+from flowpm.io import save_state
+from flowpm.tfpower import linear_matter_power
+import bigfile
+
+np.random.seed(0)
+
+
+def test_save_state():
+  """
+  Tests the BigFile saving function
+  """
+  klin = np.loadtxt('flowpm/data/Planck15_a1p00.txt').T[0]
+  plin = np.loadtxt('flowpm/data/Planck15_a1p00.txt').T[1]
+  ipklin = iuspline(klin, plin)
+  a0 = 0.1
+  nc = [16, 16, 16]
+  boxsize = [100., 100., 100.]
+  cosmo = flowpm.cosmology.Planck15()
+
+  initial_conditions = flowpm.linear_field(
+      nc,  # size of the cube
+      boxsize,  # Physical size of the cube
+      ipklin,  # Initial powerspectrum
+      batch_size=2)
+
+  # Sample particles
+  state = flowpm.lpt_init(cosmo, initial_conditions, a0)
+
+  with tempfile.TemporaryDirectory() as tmpdirname:
+    filename = tmpdirname + '/testsave'
+    save_state(cosmo, state, a0, nc, boxsize, filename)
+
+    # Now try to reload the information using BigFile
+    bf = bigfile.BigFile(filename)
+
+    # Testing recovery of header
+    header = bf['Header']
+    assert_allclose(np.array(header.attrs['NC']), np.array(nc))
+    assert_allclose(np.array(header.attrs['BoxSize']), np.array(boxsize))
+    assert_allclose(np.array(header.attrs['OmegaCDM']),
+                    np.array(cosmo.Omega_c))
+    assert_allclose(np.array(header.attrs['OmegaB']), np.array(cosmo.Omega_b))
+    assert_allclose(np.array(header.attrs['OmegaK']), np.array(cosmo.Omega_k))
+    assert_allclose(np.array(header.attrs['h']), np.array(cosmo.h))
+    assert_allclose(np.array(header.attrs['Sigma8']), np.array(cosmo.sigma8))
+    assert_allclose(np.array(header.attrs['w0']), np.array(cosmo.w0))
+    assert_allclose(np.array(header.attrs['wa']), np.array(cosmo.wa))
+    assert_allclose(np.array(header.attrs['Time']), np.array(a0))
+
+    # Testing recovery of data
+    pos = bf['1/Position']
+    assert_allclose(pos[:], state[0, 1].numpy() / nc[0] * boxsize[0])
+    vel = bf['1/Velocity']
+    assert_allclose(vel[:], state[1, 1].numpy() / nc[0] * boxsize[0])
+
+    # Closing file
+    bf.close()


### PR DESCRIPTION
This PR aims at solving #73 , it adds a simple function that will export a simulation state vector as a BigFile. It's not distributed yet, but could easily be extended to MPI in the future.

Regarding the particular format on the header and entries, I'm not sure what to use. Python-FastPM doesnt seem to have a solid format specified, maybe we should try to match C FastPM, or maybe it's ok to have our own FlowPM format.

@modichirag what do you think?